### PR TITLE
Update redirect example in readme.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,7 @@ function getPath ({navigate, location}) {
 }
 
 //Navigating to /redirect will redirect you to the result of getPath
-<Route path="/redirect">
-  <Navigate href={getPath}/>
-</Route>
+<Route path="/redirect" element={<Navigate href={getPath}/>}/>
 ```
 
 ## Dynamic Routes


### PR DESCRIPTION
The `<Navigate>` component isn't supposed to be a child of a `Route`, but declared on the `element` prop to work.